### PR TITLE
spring-boot-http-gradle to 2.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: spring-boot-http-gradle
   repository: http://jenkins-x-chartmuseum:8080
-  version: 2.0.2
+  version: 2.0.3


### PR DESCRIPTION
Promote spring-boot-http-gradle to version 2.0.3